### PR TITLE
Add NoneType check to get_type method

### DIFF
--- a/spyne/interface/xml_schema/parser.py
+++ b/spyne/interface/xml_schema/parser.py
@@ -569,7 +569,7 @@ class XmlSchemaParser(object):
 
             e = ti.elements.get(qn)
             if e:
-                if ":" in e.type:
+                if e.type and ":" in e.type:
                     return self.get_type(e.type)
                 else:
                     retval = self.get_type("{%s}%s" % (ns, e.type))


### PR DESCRIPTION
Fixes XML parser issues on schemas with no type attribute defined